### PR TITLE
Add get_command() example (fixes #2)

### DIFF
--- a/{{cookiecutter.repo_name}}/mopidy_{{cookiecutter.ext_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/mopidy_{{cookiecutter.ext_name}}/__init__.py
@@ -32,7 +32,7 @@ class Extension(ext.Extension):
         #schema['password'] = config.Secret()
         return schema
 
-    # You will typically only implement one of the next three methods
+    # You will typically only implement a couple of the next methods
     # in a single extension.
 
     # TODO: Comment in and edit, or remove entirely
@@ -44,6 +44,11 @@ class Extension(ext.Extension):
     #def get_backend_classes(self):
     #    from .backend import FoobarBackend
     #    return [FoobarBackend]
+
+    # TODO: Comment in and edit, or remove entirely.
+    #def get_command(self):
+    #    from .commands import FoobarCommand
+    #    return FoobarCommand()
 
     # TODO: Comment in and edit, or remove entirely
     #def register_gstreamer_elements(self):

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'setuptools',
-        'Mopidy >= 0.14',
+        'Mopidy >= 0.17',
         'Pykka >= 1.1',
     ],
     test_suite='nose.collector',


### PR DESCRIPTION
To be merged only after Mopidy 0.17 is released.
