### PR TITLE
Correcting attribute name

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "author_full_name": "",
+  "author_fullname": "",
   "author_email": "",
   "github_username": "",
   "dist_name": "Mopidy-Foobar",


### PR DESCRIPTION
Cloning gives "Error message: 'dict object' has no attribute 'author_fullname' ".
Attribute name is "author_full_name".
greetings :)