### PR TITLE
Use flake8 from within test environment

### DIFF
--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -19,7 +19,7 @@ deps =
     flake8
     flake8-import-order
 skip_install = true
-commands = flake8
+commands = python -m flake8
 
 [testenv:check-manifest]
 deps = check-manifest


### PR DESCRIPTION
As mentioned in the `sitepackages` section of tox's documentation, the `flake8` command should be prefixed with `python -m` to ensure the version from within the test environment is used, versus any that are externally installed: https://tox.readthedocs.io/en/latest/config.html#conf-sitepackages

Prior to this tweak, running `tox` was producing the following warning:

```
WARNING: test command found but not installed in testenv
  cmd: /usr/local/bin/flake8
  env: /mnt/c/Users/dxdec/Documents/Development/Pimoroni/Projects/mopidy-raspberry-gpio/.tox/flake8
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
```