### PR TITLE
Fix: Path issue in http:static example

### DIFF
--- a/{{cookiecutter.repo_name}}/mopidy_{{cookiecutter.ext_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/mopidy_{{cookiecutter.ext_name}}/__init__.py
@@ -44,6 +44,6 @@ class Extension(ext.Extension):
             "http:static",
             {
                 "name": self.ext_name,
-                "path": str(pathlib.Path(__file__) / "static"),
+                "path": str(pathlib.Path(__file__).parent / "static"),
             },
         )


### PR DESCRIPTION
That cost me some hair tonight. There is a `.parent` missing, which causes the http static folder to mount at `__init__.py/static`, resulting in a 404 Error from Tornado.