### PR TITLE
use-isort

### DIFF
--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -12,6 +12,7 @@ workflows:
       - black
       - check-manifest
       - flake8
+      - isort
 
 jobs:
   py38: &test-template
@@ -49,3 +50,5 @@ jobs:
   check-manifest: *test-template
 
   flake8: *test-template
+
+  isort: *test-template

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -12,6 +12,6 @@ multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
-line_length = 88
+line_length = 80
 known_tests = "tests"
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER"

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -36,7 +36,7 @@ lint =
     check-manifest
     flake8
     flake8-bugbear
-    flake8-import-order
+    flake8-isort
     isort[pyproject]
 release =
     twine
@@ -72,6 +72,8 @@ select =
     B
     # B950: line too long (soft speed limit)
     B950
+    # flake8-isort
+    I
     # pep8-naming rules
     N
 ignore =

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -21,3 +21,7 @@ commands = python -m check_manifest
 [testenv:flake8]
 deps = .[lint]
 commands = python -m flake8 --show-source --statistics
+
+[testenv:isort]
+deps = .[lint]
+commands = python -m isort --check-only .


### PR DESCRIPTION
As requested in https://github.com/mopidy/mopidy/issues/1919#issuecomment-710585695, this implements isort changes into the cookiecooker repo.

I also noticed in preparing this PR that `tox` is not included in the dev environment here, but it is located in the mopidy dev environment.  See   https://github.com/mopidy/mopidy/blob/5ebce755b930114397892e5bf6d1a59320f860f8/setup.cfg#L62-L67. I'm not sure if this is intended.
