### PR TITLE
Add tox to dev environment

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -48,6 +48,7 @@ dev =
     %(lint)s
     %(release)s
     %(test)s
+    tox
 
 
 [options.packages.find]


### PR DESCRIPTION
Noted in #19, this was added to mopidy in https://github.com/mopidy/mopidy/issues/1908, but not here.